### PR TITLE
Feature/review-product

### DIFF
--- a/src/main/java/com/mercadolibrewannabe/config/JPAConfig.java
+++ b/src/main/java/com/mercadolibrewannabe/config/JPAConfig.java
@@ -1,9 +1,29 @@
 package com.mercadolibrewannabe.config;
 
+import com.mercadolibrewannabe.model.User;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 public class JPAConfig {
+
+	@Bean
+	public AuditorAware<User> auditorProvider() {
+
+		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+				.map(SecurityContext::getAuthentication)
+				.filter(Authentication::isAuthenticated)
+				.map(Authentication::getPrincipal)
+				.filter(principal -> !principal.equals("anonymousUser"))
+				.map(User.class::cast);
+	}
+
 }

--- a/src/main/java/com/mercadolibrewannabe/controller/ReviewController.java
+++ b/src/main/java/com/mercadolibrewannabe/controller/ReviewController.java
@@ -1,0 +1,36 @@
+package com.mercadolibrewannabe.controller;
+
+import com.mercadolibrewannabe.model.Review;
+import com.mercadolibrewannabe.model.form.ReviewForm;
+import com.mercadolibrewannabe.repository.ProductRepository;
+import com.mercadolibrewannabe.repository.ReviewRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/review")
+public class ReviewController {
+
+	private final ReviewRepository reviewRepository;
+	private final ProductRepository productRepository;
+
+	public ReviewController (ReviewRepository reviewRepository, ProductRepository productRepository) {
+		this.reviewRepository = reviewRepository;
+		this.productRepository = productRepository;
+	}
+
+	@PostMapping
+	@ResponseStatus (code = HttpStatus.CREATED)
+	public void create(@RequestBody @Valid ReviewForm reviewForm) {
+
+		Review review = reviewForm.toModel(productRepository::findById);
+		reviewRepository.save(review);
+	}
+
+}

--- a/src/main/java/com/mercadolibrewannabe/model/Review.java
+++ b/src/main/java/com/mercadolibrewannabe/model/Review.java
@@ -1,0 +1,79 @@
+package com.mercadolibrewannabe.model;
+
+import org.hibernate.annotations.Type;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.Assert;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Version;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@EntityListeners (AuditingEntityListener.class)
+public class Review {
+
+	@Id
+	@GeneratedValue
+	@Type (type="uuid-char")
+	private UUID id;
+
+	@Column (nullable = false, updatable = false)
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+	@Version
+	private Integer version;
+
+	@Min (1)
+	@Max (5)
+	@NotNull
+	@Column(nullable = false)
+	private Long rating;
+
+	@NotNull
+	@Column(nullable = false)
+	private String title;
+
+	@Length (max = 500)
+	@NotNull
+	@Column(nullable = false, length = 500)
+	private String description;
+
+	@NotNull
+	@ManyToOne(optional = false)
+	private Product product;
+
+	public Review (Long rating,
+	               String title,
+	               String description,
+	               Product product) {
+
+		Assert.notNull(rating);
+		Assert.isTrue(rating >= 1 && rating <=5, "the rating must be between 1 and 5");
+		Assert.hasText(title);
+		Assert.hasText(description);
+		Assert.isTrue(description.length() <= 500, "The description max length is 500");
+		Assert.notNull(product);
+
+		this.rating = rating;
+		this.title = title;
+		this.description = description;
+		this.product = product;
+	}
+}

--- a/src/main/java/com/mercadolibrewannabe/model/Review.java
+++ b/src/main/java/com/mercadolibrewannabe/model/Review.java
@@ -2,6 +2,7 @@ package com.mercadolibrewannabe.model;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -40,6 +41,10 @@ public class Review {
 	@Version
 	private Integer version;
 
+	@ManyToOne(optional = false)
+	@CreatedBy
+	private User createdBy;
+
 	@Min (1)
 	@Max (5)
 	@NotNull
@@ -58,6 +63,13 @@ public class Review {
 	@NotNull
 	@ManyToOne(optional = false)
 	private Product product;
+
+	/**
+	 * @deprecated usage only for frameworks
+	 */
+	@Deprecated
+	public Review () {
+	}
 
 	public Review (Long rating,
 	               String title,

--- a/src/main/java/com/mercadolibrewannabe/model/Review.java
+++ b/src/main/java/com/mercadolibrewannabe/model/Review.java
@@ -43,7 +43,7 @@ public class Review {
 
 	@ManyToOne(optional = false)
 	@CreatedBy
-	private User createdBy;
+	private User user;
 
 	@Min (1)
 	@Max (5)
@@ -68,8 +68,7 @@ public class Review {
 	 * @deprecated usage only for frameworks
 	 */
 	@Deprecated
-	public Review () {
-	}
+	public Review () { }
 
 	public Review (Long rating,
 	               String title,

--- a/src/main/java/com/mercadolibrewannabe/model/form/ReviewForm.java
+++ b/src/main/java/com/mercadolibrewannabe/model/form/ReviewForm.java
@@ -1,0 +1,54 @@
+package com.mercadolibrewannabe.model.form;
+
+import com.mercadolibrewannabe.model.Product;
+import com.mercadolibrewannabe.model.Review;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class ReviewForm {
+
+	@NotNull
+	@Max(5)
+	@Min(1)
+	private Long rating;
+
+	@NotNull
+	private String title;
+
+	@NotNull
+	@Length(max = 500)
+	private String description;
+
+	@NotNull
+	private String productId;
+
+	public Long getRating () {
+		return rating;
+	}
+
+	public String getTitle () {
+		return title;
+	}
+
+	public String getDescription () {
+		return description;
+	}
+
+	public String getProductId () {
+		return productId;
+	}
+
+	public Review toModel (Function<UUID, Optional<Product>> productLoader) {
+
+		// TODO: Handle wrong id passed by Client
+		Product product = productLoader.apply(UUID.fromString(productId)).get();
+
+		return new Review(this.rating, this.title, this.description, product);
+	}
+}

--- a/src/main/java/com/mercadolibrewannabe/repository/ReviewRepository.java
+++ b/src/main/java/com/mercadolibrewannabe/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.mercadolibrewannabe.repository;
+
+import com.mercadolibrewannabe.model.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+}


### PR DESCRIPTION
Alberto,

Essa é a atividade de criar uma opinião sobre o produto. Ela ainda está dependendo do PR anterior (#5), por isso tem tantas classes para avaliar. Mas como estamos na reta final, já me adiantei e criei logo

---

Dúvidas:

1. Qual deve ser modelo de rota correto?
  - /product/{id}/review/
  - /product/review/ -> Com id no body?
  - /review - Com id no body?
  - /review/product/{id}

2. Como a nível de banco, via código, posso adicionar uma constraint de range valores? Isso é para a nota da opinião do usuário. É possível fazer isso? Ex: Para unique constraint basta incluir `@Column(unique = true)`.

3. Diferente de produto, quis experimentar a funcionalidade de Auditoria da JPA. Associei o usuário à opinião via @CreatedBy. 

Isso implica em implementar a interface `AuditorAware<T>`. Contudo, percebi que essa implementação é sempre chamada pelas classes que estão sendo auditadas (com createdDate e LastModifiedDate) ao serem persistidas. Contudo, nenhuma classe, exceto essa que acabei de criar necessitava dessa Implementação da interface, já que não precisava do Usuário logado.

Deveria ser chamada somente para auditar usuário, certo? É ter esse comportamento?

